### PR TITLE
Various formatting fixes for Stone of our Fathers

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2432,7 +2432,9 @@ event "battle in arneb end"
 		add fleet "Large Northern Pirates" 500
 		add fleet "Large Republic" 15000
 
-mission "Stone of our Fathers, part 1"
+
+
+mission "Stone of our Fathers 1"
 	name "Stone of our Fathers"
 	description "Travel to <destination> and drop Skaldgar off at the home he abandoned long ago."
 	minor
@@ -2442,19 +2444,13 @@ mission "Stone of our Fathers, part 1"
 		random < 50
 	source "Helheim"
 	destination "Norn"
-	on complete
-		payment 15000
-		event "Stone waiting" 30
-		dialog `	Skaldgar is as clean as you've seen him. Scrubbed, shaved and wearing what approximates to nice clothes, if a few decades out of style. His eyes glisten, and he turns to you.`
-				`	"I've made a lot of mistakes in my life. Comin' home, even if I am hated, or worse, forgotten, aint one of them. Thank ya kindly for the passage." `
-				`	You wish him a joyful homecoming, and watch as the old codger disappears into the sleepy spaceport. `
 	on offer
 		conversation
 			`Helheim's spaceport has all the constant hustle and bustle of a boomtown. Its' dirty, lively, and packed with workers. As you walk through the spaceport an aged man in a worn and weathered roustabout jacket waves his arm towards you and approaches you.`
 			`	"You've got the look of one who knows a ship inside and out," he says. "Names Skaldgar, ain't much for ships; earth, soil and rock are my domain. But I do got a need to travel." He pauses as a wistful look briefly passes over his face, "I left, you see, decades ago. No goodbye. No note. Just... left. Living with others, taking care of others, hard on a man like me, I like solitude, peace, and work. But now my bones are brittle, the radiation, earth-rot as we call it, has taken hold and my time is running out. And I find, I don't want to be alone anymore." `
 			`	He stops and frowns, "Look at me, rambling like an ol' man. Ser, Captain, I'd like to pay you <payment> to take me home, to <destination>" `
 			choice
-				`	(If you have coin, I have room)`
+				`	"If you have coin, I have room."`
 					goto accept
 				`	(You shake your head. You have better things to do then bus old men around.)`
 					goto decline
@@ -2464,13 +2460,20 @@ mission "Stone of our Fathers, part 1"
 			label decline
 			`	He nods once, with a disappointed look on his face and slides back into the endless sea of people.`
 				decline
-				
+	on visit
 		dialog `You have reached <planet>, but your escort with the space reserved for Skaldgar has not arrived! Better depart and wait for your escorts to arrive in this star system.`
+	on complete
+		payment 15000
+		event "Stone waiting" 30
+		dialog `Skaldgar is as clean as you've seen him. Scrubbed, shaved and wearing what approximates to nice clothes, if a few decades out of style. His eyes glisten, and he turns to you.`
+			`	"I've made a lot of mistakes in my life. Comin' home, even if I am hated, or worse, forgotten, aint one of them. Thank ya kindly for the passage." `
+			`	You wish him a joyful homecoming, and watch as the old codger disappears into the sleepy spaceport. `
 		
 event "Stone waiting"	
-		
-		
-mission "Stone of our Fathers, part 2"
+
+
+
+mission "Stone of our Fathers 2"
 	name "Stone of our Fathers"
 	description "Return Skaldgar to <destination>."
 	minor
@@ -2478,23 +2481,18 @@ mission "Stone of our Fathers, part 2"
 	cargo "Just an old man and his things" 1
 	to offer
 		has "event: Stone waiting"
-		has "Stone of our Fathers, part 1: done"
+		has "Stone of our Fathers 1: done"
 	source "Norn"
 	destination "Helheim"
-	on complete
-		event "Stone Waiting more" 60
-		payment 25000
-		dialog ` Helheim's hustle and bustle threatens to overwhelm the senses, yet Skaldgar, for all his age and illness, seems to have a skip in his step as he saunters out of your ship and into the teeming masses.`
-			`	Just as he is about to be swept up in the current of humanity, Skaldgar turns and gives you one last wave, and then is gone.`
 	on offer
 		conversation
 			`In the nearly abandoned spaceport of Norn a scruffy and slow moving figure moves towards you. As they approach you recognize the well-creased face of Skaldgar.`
 			`	He grins and waves to you. "Gotta a nephew who works at the port, let me know he saw you comin' in." He claps you on the back, "Things have been mostly good, hard though, the family - some are glad to see me, to remember me, and others..," he pauses, "well, some mistakes you just can't take back."`
 			`	He looks away briefly, and then nods at his packed bag, "It was good to come back here one last time. But the soil, the work calls to me. I am only good at one thing in this world and I intend to do it to the very end. So, I was wonderin', could ya take me back to <destination>?`
 			choice
-				"	(You nod. Skaldgar and his hard earned money are more than welcome aboard your ship.)"
+				`	(You nod. Skaldgar and his hard earned money are more than welcome aboard your ship.)`
 					goto accept
-				"	(You decline. You have better things to do then bus old men around.)"
+				`	(You decline. You have better things to do then bus old men around.)`
 					goto decline
 			label decline
 			`	Skaldgar glares at you briefly then shrugs. "S'pose you do. S'pose you do." He turns and wanders away. `
@@ -2504,25 +2502,26 @@ mission "Stone of our Fathers, part 2"
 				accept
 	on visit
 		dialog `You have reached <planet>, but your escort with the space reserved for Skaldgar has not arrived! Better depart and wait for your escorts to arrive in this star system.`
+	on complete
+		event "Stone Waiting more" 60
+		payment 25000
+		dialog `Helheim's hustle and bustle threatens to overwhelm the senses, yet Skaldgar, for all his age and illness, seems to have a skip in his step as he saunters out of your ship and into the teeming masses.`
+			`	Just as he is about to be swept up in the current of humanity, Skaldgar turns and gives you one last wave, and then is gone.`
 		
 event "Stone Waiting more"
 
 
-mission "Stone of our Fathers, part 3"
+
+mission "Stone of our Fathers 3"
 	name "Stone of our Fathers"
-	description " Take Skaldgar's stone back to his family on <destination>."
+	description "Take Skaldgar's stone back to his family on <destination>."
 	minor
 	cargo "Family stone" 1
 	to offer
 		has "event: Stone Waiting more"
-		has "Stone of our Fathers, part 2: done"
+		has "Stone of our Fathers 2: done"
 	source "Helheim"
 	destination "Norn"
-	on complete
-		payment 15
-		dialog ` It turns out there is no need to search for Helm, as he is waiting for you when you land. `
-			`	"I figured for you to be returning, it would either be with Skaldgar or with," he pauses," news." He looks around, "and I don't see Skaldgar." `
-			`	You show him the odd stone you'd been given and Helm stiffens then nods. "As I figured, best we meet in the spaceport to discuss what comes next." `
 	on offer
 		conversation
 			`As always, Helheim is packed to the brim with transient workers coming and going, with dreams of either getting rich, or getting out. A youngish looking man, in a dirty roustabout jacket waves at you and approaches.`
@@ -2530,11 +2529,9 @@ mission "Stone of our Fathers, part 3"
 			`	The young man then looks down, somberly, and pulls from his pocket a small well-worn stone with some strange markings on it and holds it out to you.` 
 			`	"He wanted," he begins haltingly, "he wanted you, only you, to take this back to his folk on Norn." He swallows, "It's the old ways, it is. This, it needs to be returned, and not by a stranger." The young man then shrugs, "Best to letcha know, I aint have no money to pay you. This would have to be done as a favor for the ol' man."`
 			choice
-				"	(You reach out and accept the stone)"
+				`	(You reach out and accept the stone)`
 					goto accept
-				"	(You decline. You run a ship not a charity.)"
-					goto decline
-			label decline
+				`	(You decline. You run a ship not a charity.)`
 			`	The young roustabout nods knowingly. "Guess Skaldgar was wrong about you, but I understand. We all gotta eat." He turns and slides back into the endless crowd. `
 				decline
 			label accept
@@ -2544,21 +2541,27 @@ mission "Stone of our Fathers, part 3"
 				accept
 	on visit
 		dialog `You have reached <planet>, but your escort with the space reserved for the stone has not arrived! Better depart and wait for your escorts to arrive in this star system.`
+	on complete
+		payment 15
+		dialog ` It turns out there is no need to search for Helm, as he is waiting for you when you land.`
+			`	"I figured for you to be returning, it would either be with Skaldgar or with," he pauses," news." He looks around, "and I don't see Skaldgar."`
+			`	You show him the odd stone you'd been given and Helm stiffens then nods. "As I figured, best we meet in the spaceport to discuss what comes next."`
 
 
-mission "Stone of our Fathers, part 4"
+
+mission "Stone of our Fathers 4"
 	name "Stone of our Fathers"
-	description " Take Skaldgar's stone back to his family carin <destination>."
+	description "Take Skaldgar's stone back to his family carin <destination>."
 	minor
 	cargo "Family stone" 1
 	to offer
-		has "Stone of our Fathers, part 3: done"
+		has "Stone of our Fathers 3: done"
 	source "Norn"
 	destination "Alfheim"
 	on complete
 		payment 1
 		conversation 
-			` 	The journey to Alfheim was interesting, if uneventful. Thorleif had never been in space before, and every jump left him quite ill. But at the same time, he found so much wonder in it. Seeing the dark void and bright stars with his own eyes. Watching the tiny worlds in the distance. You could, through his eyes, experience the wild adventure of space anew.`
+			`The journey to Alfheim was interesting, if uneventful. Thorleif had never been in space before, and every jump left him quite ill. But at the same time, he found so much wonder in it. Seeing the dark void and bright stars with his own eyes. Watching the tiny worlds in the distance. You could, through his eyes, experience the wild adventure of space anew.`
 			`	Throughout the trip he told you stories of his family, they were called the Hlewagast and originally settled as some of the first colonists on Alfheim in the early history of The Deep. How they had been explorers and adventurers before taking land here to settle down on and work. How his great grandparents had decided to leave Alfheim, dismayed by the rampant pillaging of resources and looking once more for adventure, and how they had come to Norn. Seeking the waves, and the storms, and the solitude.`
 			`	Through all of this you got a better feel for Thorleif, Skaldgard and his people, and were almost sorry when your ship approached Alfheim.`
 			`	On landing you are surprised by how much Alfheim reminds you of Helheim. Though the environment and ecology of the worlds are remarkably different, both are primarily used for resource extraction. Filled with boomtown employees and roustabouts, looking for work, chasing dreams, and trying to make their way in the world.`
@@ -2568,9 +2571,9 @@ mission "Stone of our Fathers, part 4"
 			`Helm meets you in the nearly deserted Spaceport bar. "Ma' always had a soft spot for Uncle Skaldgar, even after he ran off 35 years ago, she still spoke fondly of him. He always sent the family money, he was good like that. Not as good, though, in sending his love."`
 			`	Helm sighs, "This is going to be tough, but as bearer of the Stone, you are going to need to present it to his son. His family lives on a floating island to the south of here. Are you willing to accompany me?"`
 			choice
-				"	(You've come this far, you might as well finish it.)"
+				`	(You've come this far, you might as well finish it.)`
 					goto accept
-				"	(No. This is as far as you go. Helm is family and it's his problem now.)"
+				`	(No. This is as far as you go. Helm is family and it's his problem now.)`
 					goto decline
 			label decline
 			` 	Helm nods, knowingly, "Fair enough star-traveler, I will handle it from here." `
@@ -2582,16 +2585,15 @@ mission "Stone of our Fathers, part 4"
 			`	Helm pauses as a flock of jabbering sea-birds passes near the ship, indicating a nearby floating island, and then continues, "And then when that person dies, that stone is returned by the closest family member to the Family-Cairn."` 
 			`	Helm looks up and his eyes scan the horizon. "We're almost there, gather your things." Helm stands and returns to the ship's controls.` 
 			choice
-				`	(But why do I have to be the one to bring the stone to his son?)`
+				`	"But why do I have to be the one to bring the stone to his son?"`
 					goto why
-				`	(Where do the stones come from?)`
+				`	"Where do the stones come from?"`
 					goto from
 			label why
 			`	Helm shrugs as he maneuvers the ship into dock, "It is the old way. To make certain the stone is not lost, mishandled, or acquired by enemies. If the family is not near when its owner passes, it is given to a trusted friend who becomes its bearer. That task is too important and too sacred to be given to a stranger or courier. For you to take it all the way to his son, so that he may return it to earth, is right."`
 					goto earth
 			label from
 			`	Helm shrugs as he maneuvers the ship into dock, "Wherever makes the most sense at the time a stone is given. If I recall correctly Skaldgar's stone was given to him by his mother, my grandmother, from an old mine Skaldgar had been exploring on the mainland. Even at 16 he loved the earth."`
-					goto earth
 			label earth
 			` 	Helm ties the ship up and you follow him towards a grey and dour building not far from the makeshift dock. You realize this entire algae island, as small as it is, must belong to a single individual or family.` 
 			`	When you arrive at the hardy and sea-stained wooden door, Helm knocks thunderously upon it and calls, out "Thorleif, open up!"`
@@ -2607,7 +2609,6 @@ mission "Stone of our Fathers, part 4"
 					goto stone
 			label helm
 			`	Helm puts a hand on Thorleif's shoulder, "This here is <first>, they've come a long way to see you, and to bring you Skaldgar's stone."`
-					goto stone
 			label stone
 			`	Thorleif tenses up, "Never speak that name!" His eyes narrow, "Helm, I want nothing to do with that stone, this person," Thorleif gestures towards you," or whatever else that old man wanted or cared about."`
 			`	Thorleif glances towards the horizon as he clenches and unclenches his fists, taking a few slow breaths, regaining his composure, "I realize you have traveled far and would not be able to get back to the mainland before night. So you may stay in the guest quarters, and leave first thing in the morning. I will have no one say that Thorleif was inhospitable."`
@@ -2624,15 +2625,12 @@ mission "Stone of our Fathers, part 4"
 			`	Helm then turns his attention to a small window and the darkening horizon beyond it. "Dark clouds are gathering, I fear we may be here longer than a single night."`
 			choice
 				`	(You head to bed as the first rains begin to patter against the roof.)`
-					goto patter
-			label patter
 			`	You awake to riotous rain pelting hard against the walls. As Helm predicted a powerful storm blew in over the night, and the floating island found itself besieged by savage weather. By midmorning the walls are starting to creak as the howling wind bashes against it unceasingly.` 
 			`	You hear a door open and struggle to close. Then the sound of heavy sloshing footsteps. Thorleif, soaked to the bone, stands before you and Helm in the main room, "It's a Fimbulhrithr," Thorleif exclaims, "One of the worst I've yet seen. If we do not act quickly it could well flatten everything on this isle. Will you help me?" `
 			choice
 				`	(You offer to help Thorleif.)`
 					goto help
 				`	(You shake your head and stubbornly refuse to help. You've done more than enough for this family and see no reason to lend a hand to Skaldgar's estranged son. Especially for free!)`
-					goto refuse
 			label refuse
 			`	Thorleif growls, "Knew better than to trust a friend of that useless old man. I gave you a place to sleep, and now you won't lift a hand to save it? I should have expected no less!" Thorleif and Helm hurry off to tend to the island during the storm, leaving you warm and cozy and idle inside.` 
 			`	Thorleif and Helm heoricially manage to steer the island away from the storm, and to calmer safer seas. However, with only the two of them many of the out-buildings are destroyed along with a few of the small watercraft Thorleif used to fish and work on.` 
@@ -2665,22 +2663,16 @@ mission "Stone of our Fathers, part 4"
 			`	You could always use a little extra money, and this trip, while engaging, has certainly not made you any richer, so you ask about hidden treasures. Helm and Thorleif both grin at this and glance at each other knowingly. They launch into tales of the riches of lost civilizations, or forgotten pirate hoards, or even early human kingdoms. It's easy to lose things on a fog-covered ocean world with floating islands, all too easy. `
 			`	When they are done regaling you with tales they mention to you that maybe some other time they'll take you out into the deep ocean and perhaps you'll find what you're looking for. They smile wolfishly at that and you think they might be putting you on. "Have you ever found treasure out here?" you ask. `
 			`	Thorleif shrugs, "coming here.. from Alfheim long ago, our descendants felt that the world itself was the real treasure. We have no need to go tracing dreams in the abyss."`
-					goto family
-			label family
 			`	As the conversation winds down and the hour grows late Helm excuses himself to bed, for he, like the rest of you, is bone tired after the day's events. You stand too, feeling your own need for sleep. `
 			`	"<first>," Thorleif says without looking up from the fire. "I've been thinking. I can never forgive him for what he did. Leaving me and mom like that. But I can, I think, make peace with it. I can accept the stone." He looks up and smiles, "You brought some luck with you, and a man should never argue with luck." `
 			`	He stands up, "We'll talk in the morning."`
 			choice
 				`	(You head to bed for some well deserved sleep.)`
-					goto morning
-			label morning
 			`	The day is bright and the sky is clear. The storm long forgotten as you prepare your things. Out in the main room Thorleif and Helm are waiting for you, and Thorleif opens up his hand to accept the stone, which you gladly place into it. He smiles and looks it over, tracing his finger along its chiseled runes.`
 			`	"Thank you <first>". You nod, glad to be done with this mission and free to ply the space lanes once more. `
 			`	"Just more thing," Thorleif adds with a big stupid grin, "I'll need a captain willing to ferry me to Alfheim. That's where my family's carin is located." `
 			choice
 				`	(After all you've been through you don't see any way to refuse the request.)`
-					goto agree
-			label agree
 			`	"Of course," you answer, and before you know it the three of you are on Helm's boat and heading for the spaceport. `
 			`	"Alfheim," Thorleif says idly, "you know of it? The name means the home of the Alfar, or elves as you call them. I've never been there, only heard of it. It'll be strange to visit the world of my ancestors." `
 			`	Helm stays behind as you and Thorleif load your gear onto your ship.` 
@@ -2688,29 +2680,19 @@ mission "Stone of our Fathers, part 4"
 				accept
 	on visit
 		dialog `You have reached <planet>, but your escort with the space reserved for Thorleif has not arrived! Better depart and wait for your escorts to arrive in this star system.`
-		
-		
-mission "Stone of our Fathers, part 5"
+
+
+
+mission "Stone of our Fathers 5"
 	name "Stone of our Fathers"
 	description " Take Skaldgar's stone back to his family on <destination>."
 	minor
 	passengers 2
 	cargo "Thorleif and Ragnhild" 1
 	to offer
-		has "Stone of our Fathers, part 4: done"
+		has "Stone of our Fathers 4: done"
 	source "Alfheim"
 	destination "Norn"
-	on complete
-		payment 500000
-		conversation 
-			` The trip back to Norn was restful.` 
-			`	You spent most of it listening to Ragnhild tell the old stories and legends of Alfheim that she had learnt in her girlhood.`
-			`	Stories about alien trees whispering dark secrets, of Oil-Barons destroying sacred sites and being cursed by alien artefacts they were too blinded by greed to see, and even tales of the elves and miracles of the Elf-Stones.` 
-			`	Again, as before, you're almost sad when you make it back to Norn and the time for telling stories has ended, and the time for saying goodbye has begun.`
-			`	Thorleif wraps you in a bear hug. "I thank you for all you have done <first>. I was so wound up in my own anger and bitterness I couldn't see anything beyond my own pain. But now, I feel like I can live again. Trust, that our meeting has been etched into my own stone. I hope someday you come back and visit us. To remember us small folk on a small world so far from places of power and grand events. Remember you'll always have a home here."`
-			`	With that Thorleif and Ragnhild make their way off your ship. Thorleif only takes a few steps out into the quiet Norn Starport, before stopping suddenly and turning back towards you.`
-			`	"I almost forgot. The old man, Skaldgar, well he had quite a bit of money saved up. I don't think he hardly spent anything on himself. Anyways, I've decided to split the inheritance with you. After taxes your half comes out to around 500,000 even."`
-			`	Thorleif, shrugs, laughs and walks with Ragnhild hand in hand out into the foggy mists of Norn.` 
 	on offer
 		conversation
 			`Thorleif clearly is uncomfortable being in a place so jam packed with people. You help him keep his bearings and work your way to a young woman managing a visitor kiosk in the Spaceport.`
@@ -2730,7 +2712,6 @@ mission "Stone of our Fathers, part 5"
 			`	She smiles broadly at Thorleif and nods.`
 			choice
 				`	(You sigh and shake your head.)`
-					goto accompany
 			label accompany
 			`	She immediately abandons her kiosk and shrugs, "I didn't care much for that job anyways."` 
 			`	You and Thorleif follow her to a local transit hovercraft, where she and Thorleif quickly sit together and you find yourself sitting alone.`
@@ -2738,7 +2719,6 @@ mission "Stone of our Fathers, part 5"
 			`	At some point you feel Thorleif shaking your shoulder. "We're here."`
 			choice
 				`	(You yawn and rise from your seat.)`
-					goto here
 			label here
 			`	The town of Grimssalr is nestled along the foothills of the towering Ettin mountains in western Alfheim. Town, is perhaps too generous a word, it is instead more like a couple dozen houses mostly filled with old people long abandoned by their children seeking wealth and adventure elsewhere.`
 			`	The woman, who you've learnt is named Ragnhild, introduces Thorleif to some of the folks here and before long they have found ways to connect their ancient genealogies together and everyone is suddenly treated as family. You eat their meager fare, swap stories, and listen to legends about the old times.`
@@ -2770,8 +2750,6 @@ mission "Stone of our Fathers, part 5"
 			`	The two of you trudge back to the small hamlet of Grimssalr, with its people happy at having guests and long lost relatives, and to Ragnhild, happy to spend more time with Thorlief, where you feast and talk and laugh and remember.`
 			choice
 				`	(You enjoy yourself well into the night before finally succumbing to sleep.)`
-					goto morning
-			label morning
 			`	In the morning the three of you catch the hovercraft back to the spaceport.` 
 			`	"This place," Thorleif begins, "this world, it feels like it has forgotten its soul. Industry, and greed have taken hold, and the old happy places like Grimssalr are dying. It is good my family left here all those years ago. Norn is, and has been, a good place to be."` 
 			`	Thorleif than nods to Ragnhild, "Which is also why my very new and very dear friend Ragnhild has decided to join us on the return trip to Norn." You look to Ragnhild but somehow you can't feel that you're surprised at the news.` 
@@ -2779,3 +2757,14 @@ mission "Stone of our Fathers, part 5"
 				accept
 	on visit
 		dialog `You have reached <planet>, but your escort with the space reserved for Thorleif and Ragnhild has not arrived! Better depart and wait for your escorts to arrive in this star system.`
+	on complete
+		payment 500000
+		conversation 
+			`The trip back to Norn was restful.` 
+			`	You spent most of it listening to Ragnhild tell the old stories and legends of Alfheim that she had learnt in her girlhood.`
+			`	Stories about alien trees whispering dark secrets, of Oil-Barons destroying sacred sites and being cursed by alien artefacts they were too blinded by greed to see, and even tales of the elves and miracles of the Elf-Stones.` 
+			`	Again, as before, you're almost sad when you make it back to Norn and the time for telling stories has ended, and the time for saying goodbye has begun.`
+			`	Thorleif wraps you in a bear hug. "I thank you for all you have done <first>. I was so wound up in my own anger and bitterness I couldn't see anything beyond my own pain. But now, I feel like I can live again. Trust, that our meeting has been etched into my own stone. I hope someday you come back and visit us. To remember us small folk on a small world so far from places of power and grand events. Remember you'll always have a home here."`
+			`	With that Thorleif and Ragnhild make their way off your ship. Thorleif only takes a few steps out into the quiet Norn Starport, before stopping suddenly and turning back towards you.`
+			`	"I almost forgot. The old man, Skaldgar, well he had quite a bit of money saved up. I don't think he hardly spent anything on himself. Anyways, I've decided to split the inheritance with you. After taxes your half comes out to around 500,000 even."`
+			`	Thorleif, shrugs, laughs and walks with Ragnhild hand in hand out into the foggy mists of Norn.` 


### PR DESCRIPTION
Merging this PR will fix various formatting issues with the first draft, to make it more consistent with other Endless Sky missions. The main things are:

- Re-ordered the conversations to on offer > on visit > on complete
- Added quotes around spoken dialog from the player, rather than parenthesis
- Ensured three line breaks between every mission, to make it clear when a new one happens to someone skimming the data
- Renamed missions from "Stone of our Fathers, Part <X>" to just "Stone of our Fathers <X>", like other mission strings
- Removed redundant goto commands or labels. Remember that Endless Sky conversations will always continue forward unless you tell them otherwise. If you're telling the game to jump to the next line, that can just be removed.